### PR TITLE
Fix/api types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -440,6 +440,7 @@ export type ConnectorType = 'PERSONAL_BANK' | 'BUSINESS_BANK' | 'INVOICE' | 'INV
 
 export type IdentityResponse = {
   id: string
+  itemId: string
   birthDate?: Date
   taxNumber?: string
   document?: string
@@ -450,6 +451,8 @@ export type IdentityResponse = {
   emails?: Email[]
   addresses?: Address[]
   relations?: IdentityRelation[]
+  createdAt: Date
+  updatedAt: Date
 }
 
 export type PhoneNumber = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,26 @@ export type Transaction = {
 }
 
 /**
+ * @typedef CredentialType
+ * credential type, used to show a proper form input to the user
+ * 'number' -> numeric only data
+ * 'text' -> alpha-numeric data
+ * 'password' -> alpha-numeric password, must be obfuscated
+ * 'select' -> credential has to be picked from values listed in credential.options field
+ */
+export type CredentialType = 'number' | 'password' | 'text' | 'select'
+
+/**
+ * @typedef CredentialSelectOption
+ * @property {string} label - the text to display to the user for this option
+ * @property {string} value - the actual value for this option
+ */
+export type CredentialSelectOption = {
+  value: string
+  label: string
+}
+
+/**
  * @typedef ConnectorCredential
  * @type {object}
  * @property {string} label - parameter label that describes it
@@ -237,6 +257,7 @@ export type Transaction = {
  * @property {string} validationMessage - Validation error message to show to the user
  * @property {boolean} optional - Useful to allow the user to skip/ignoring an unneeded parameter
  * @property {string} assistiveText - Assistive information (supplied by the connector/site) to help the user provide the extra MFA credential
+ * @property {CredentialSelectOption[]} options - Available options if credential is of type 'select'
 
  */
 export type ConnectorCredential = {
@@ -249,16 +270,8 @@ export type ConnectorCredential = {
   validationMessage?: string
   optional: boolean
   assistiveText?: string
+  options?: CredentialSelectOption[]
 }
-
-/**
- * @typedef CredentialType
- * credential type, used to show a proper form input to the user
- * 'number' -> numeric only data
- * 'text' -> alpha-numeric data
- * 'password' -> alpha-numeric password, must be obfuscated
- */
-export type CredentialType = 'number' | 'password' | 'text'
 
 /**
  * @typedef Connector

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,8 @@ export type Transaction = {
  * @property {string} validation - Validation regex to check on the submitted parameter value, before execution
  * @property {string} validationMessage - Validation error message to show to the user
  * @property {boolean} optional - Useful to allow the user to skip/ignoring an unneeded parameter
+ * @property {string} assistiveText - Assistive information (supplied by the connector/site) to help the user provide the extra MFA credential
+
  */
 export type ConnectorCredential = {
   label: string
@@ -246,6 +248,7 @@ export type ConnectorCredential = {
   validation?: string
   validationMessage?: string
   optional: boolean
+  assistiveText?: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,7 @@ export type InvestmentTransaction = {
  * @property {string} number - Account's provider number
  * @property {number} balance - Current balance of the account
  * @property {string} name - Account's name or description
- *
+ * @property {CurrencyCode} currencyCode - ISO Currency code of the investment
  *
  */
 export type AccountBase = {
@@ -143,6 +143,7 @@ export type AccountBase = {
   number: string
   balance: number
   name: string
+  currencyCode: CurrencyCode
 }
 
 /**
@@ -158,7 +159,6 @@ export type AccountBase = {
  * @property {string} marketingName - Account's name provided by the institution based on the level of client.
  * @property {string} owner - Account's owner´s name
  * @property {string} taxNumber - Account's owner´s tax number
- * @property {CurrencyCode} currencyCode - ISO Currency code of the investment
  * @property {BankData} bankData - Account related banking data
  * @property {CreditData} creditData - Account related credit data
  */
@@ -166,9 +166,8 @@ export type Account = AccountBase & {
   marketingName: string | null
   owner: string | null
   taxNumber: string | null
-  currencyCode: CurrencyCode
-  bankData?: BankData
-  creditData?: CreditData
+  bankData: BankData | null
+  creditData: CreditData | null
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,9 +231,10 @@ export type Transaction = {
  * 'number' -> numeric only data
  * 'text' -> alpha-numeric data
  * 'password' -> alpha-numeric password, must be obfuscated
+ * 'image' -> a QR code needs to be decoded (QR is provided in the credential.data field)
  * 'select' -> credential has to be picked from values listed in credential.options field
  */
-export type CredentialType = 'number' | 'password' | 'text' | 'select'
+export type CredentialType = 'number' | 'password' | 'text' | 'image' | 'select'
 
 /**
  * @typedef CredentialSelectOption

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,11 +228,11 @@ export type Transaction = {
 /**
  * @typedef CredentialType
  * credential type, used to show a proper form input to the user
- * 'number' -> numeric only data
- * 'text' -> alpha-numeric data
- * 'password' -> alpha-numeric password, must be obfuscated
- * 'image' -> a QR code needs to be decoded (QR is provided in the credential.data field)
- * 'select' -> credential has to be picked from values listed in credential.options field
+ *  'number' -> numeric only data
+ *  'text' -> alpha-numeric data
+ *  'password' -> alpha-numeric password, must be obfuscated
+ *  'image' -> a QR code needs to be decoded (QR is provided in the credential.data field)
+ *  'select' -> credential has to be picked from values listed in credential.options field
  */
 export type CredentialType = 'number' | 'password' | 'text' | 'image' | 'select'
 
@@ -253,19 +253,20 @@ export type CredentialSelectOption = {
  * @property {string} name - parameter key name
  * @property {CredentialType} type - type of parameter, used to create the form
  * @property {boolean} mfa - If parameter is used for MFA.
+ * @property {string} data - Code for QR image to be resolved (credential type 'image')
  * @property {string} placeholder - Text to use for parameter placeholder in form
  * @property {string} validation - Validation regex to check on the submitted parameter value, before execution
  * @property {string} validationMessage - Validation error message to show to the user
  * @property {boolean} optional - Useful to allow the user to skip/ignoring an unneeded parameter
  * @property {string} assistiveText - Assistive information (supplied by the connector/site) to help the user provide the extra MFA credential
  * @property {CredentialSelectOption[]} options - Available options if credential is of type 'select'
-
  */
 export type ConnectorCredential = {
   label: string
   name: string
   type?: CredentialType
   mfa?: boolean
+  data?: string
   placeholder?: string
   validation?: string
   validationMessage?: string


### PR DESCRIPTION
Implementing many fixes for types that were out-of-sync.

Some of these changes were needed to correctly provide types in Pluggy Connect widget projects (pluggy-connect, and react-pluggy-connect), by reusing pluggy-js as a peer dependency.

Also for this to work it's necesary to re-use the same type definitions in connect project, which also need to be correct for the app to actually work. 

This will allow removing repeated type definitions / logic in connect webapp, which by the way most of them were out of sync with the some recent Core API changes (such as 'select' credential, 'assistiveText', etc..) and some not so recent but haven't been considered/used before.

Also will help in allowing removing duplicated logic/typings from demo webapp as well.