### PR TITLE
Fix/error responses

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "singleQuote": true,
   "semi": false,
   "trailingComma": "es5",
-  "printWidth": 100
+  "printWidth": 80
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.20.0"
+        "axios": "^0.21.1"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^2.16.0",
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
@@ -751,11 +751,22 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -2265,9 +2276,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -2667,9 +2678,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "pluggy-js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluggy-js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "browser"
   ],
   "dependencies": {
-    "axios": "^0.20.0"
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.16.0",

--- a/src/pluggy.ts
+++ b/src/pluggy.ts
@@ -13,7 +13,6 @@ import {
   Transaction,
   TransactionFilters,
   TransactionsPageResponse,
-  ValidationErrorResponse,
   Parameters,
 } from './types'
 
@@ -64,12 +63,13 @@ class Pluggy extends BaseApi {
    * @param parameters A map of name and value for the needed credentials
    * @param webhookUrl - The webhookUrl to send item notifications to (optional)
    * @returns {Item} a item object
+   * @throws {AxiosError<ValidationErrorResponse> axios-wrapped Error with validation error details
    */
   async createItem(
     connectorId: number,
     parameters: Parameters,
     webhookUrl?: string
-  ): Promise<Item | ValidationErrorResponse> {
+  ): Promise<Item> {
     return this.createPostRequest(`items`, null, {
       connectorId,
       parameters,
@@ -83,12 +83,13 @@ class Pluggy extends BaseApi {
    * @param parameters A map of name and value for the credentials to be updated
    * @param webhookUrl - The new webhookUrl to send item notifications to (optional)
    * @returns {Item} a item object
+   * @throws {AxiosError<ValidationErrorResponse> axios-wrapped Error with validation error details
    */
   async updateItem(
     id: string,
     parameters?: Parameters,
     webhookUrl?: string
-  ): Promise<Item | ValidationErrorResponse> {
+  ): Promise<Item> {
     return this.createPatchRequest(`items/${id}`, null, {
       id,
       parameters,

--- a/src/pluggy.ts
+++ b/src/pluggy.ts
@@ -26,8 +26,12 @@ class Pluggy extends BaseApi {
   /**
    * Fetch all available connectors
    * @returns {Connector[]} an array of connectors
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
-  async fetchConnectors(options: ConnectorFilters = {}): Promise<PageResponse<Connector>> {
+  async fetchConnectors(
+    options: ConnectorFilters = {}
+  ): Promise<PageResponse<Connector>> {
     return this.createGetRequest('connectors', { ...options })
   }
 
@@ -35,6 +39,9 @@ class Pluggy extends BaseApi {
    * Fetch a single Connector
    * @param id The Connector ID
    * @returns {Connector} a connector object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If specified Connector by 'id' does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchConnector(id: number): Promise<Connector> {
     return this.createGetRequest(`connectors/${id}`)
@@ -43,6 +50,8 @@ class Pluggy extends BaseApi {
   /**
    * Fetch all items from the client
    * @returns {Item[]} list of connected items
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
   async fetchItems(): Promise<PageResponse<Item>> {
     return this.createGetRequest(`items`)
@@ -52,6 +61,9 @@ class Pluggy extends BaseApi {
    * Fetch a single item
    * @param id The Item ID
    * @returns {Item} a item object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If specified Item by 'id' does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchItem(id: string): Promise<Item> {
     return this.createGetRequest(`items/${id}`)
@@ -62,8 +74,11 @@ class Pluggy extends BaseApi {
    * @param connectorId The Connector's id
    * @param parameters A map of name and value for the needed credentials
    * @param webhookUrl - The webhookUrl to send item notifications to (optional)
-   * @returns {Item} a item object
-   * @throws {AxiosError<ValidationErrorResponse> axios-wrapped Error with validation error details
+   * @returns {Item} the created Item object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If connector is not found or accessible, status 403 if user is unauthorized
+   * @throws {AxiosError<ValidationErrorResponse>} if 'connectorId' or 'webhookUrl' are invalid
+   * @throws {AxiosError<ConnectorValidationErrorResponse>} if provided 'parameters' fail for some connector validation rules
    */
   async createItem(
     connectorId: number,
@@ -82,8 +97,12 @@ class Pluggy extends BaseApi {
    * @param id The Item ID
    * @param parameters A map of name and value for the credentials to be updated
    * @param webhookUrl - The new webhookUrl to send item notifications to (optional)
-   * @returns {Item} a item object
-   * @throws {AxiosError<ValidationErrorResponse> axios-wrapped Error with validation error details
+   * @returns {Item} the updated Item object
+   *
+   * @throws {AxiosError<ValidationErrorResponse>} if 'connectorId' or 'webhookUrl' are invalid
+   * @throws {AxiosError<ConnectorValidationErrorResponse>} if provided 'parameters' fail for some connector validation rules
+   * @throws {AxiosError<ErrorResponse>} status 404 If connector is not found or accessible,
+   *                                     status 403 if user is unauthorized
    */
   async updateItem(
     id: string,
@@ -102,6 +121,11 @@ class Pluggy extends BaseApi {
    * @param id The Item ID
    * @param parameters A map of name and value for the mfa requested
    * @returns {Item} a item object
+   *
+   * @throws {AxiosError<ValidationErrorResponse>} if item 'id' is invalid
+   * @throws {AxiosError<ConnectorValidationErrorResponse>} if provided 'parameters' with the MFA value fail connector validation rules
+   * @throws {AxiosError<ErrorResponse>} status 404 If item is not waiting an MFA request (or has already been fulfilled),
+   *                                     status 403 if user is unauthorized
    */
   async updateItemMFA(id: string, parameters?: Parameters): Promise<Item> {
     return this.createPostRequest(`items/${id}/mfa`, null, parameters)
@@ -109,6 +133,10 @@ class Pluggy extends BaseApi {
 
   /**
    * Deletes an item
+   *
+   * @throws {AxiosError<ValidationErrorResponse>} if item 'id' is invalid
+   * @throws {AxiosError<ErrorResponse>} status 404 If item does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async deleteItem(id: string): Promise<void> {
     return this.createDeleteRequest(`items/${id}`)
@@ -119,14 +147,22 @@ class Pluggy extends BaseApi {
    * @param itemId The Item id
    * @param type - AccountType filter (optional)
    * @returns {Account[]} an array of accounts
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
-  async fetchAccounts(itemId: string, type?: AccountType): Promise<PageResponse<Account>> {
+  async fetchAccounts(
+    itemId: string,
+    type?: AccountType
+  ): Promise<PageResponse<Account>> {
     return this.createGetRequest('accounts', { itemId, type })
   }
 
   /**
    * Fetch a single account
    * @returns {Account} an account object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If account does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchAccount(id: string): Promise<Account> {
     return this.createGetRequest(`accounts/${id}`)
@@ -137,6 +173,8 @@ class Pluggy extends BaseApi {
    * @param accountId The account id
    * @param {TransactionFilters} options Transaction options to filter
    * @returns {Transaction[]} an array of transactions
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
   async fetchTransactions(
     accountId: string,
@@ -148,6 +186,9 @@ class Pluggy extends BaseApi {
   /**
    * Fetch a single transaction
    * @returns {Transaction} an transaction object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If transaction does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchTransaction(id: string): Promise<Transaction> {
     return this.createGetRequest(`transactions/${id}`)
@@ -158,14 +199,22 @@ class Pluggy extends BaseApi {
    * @param itemId The Item id
    * @param type - InvestmentType filter (optional)
    * @returns {Investment[]} an array of investments
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
-  async fetchInvestments(itemId: string, type?: InvestmentType): Promise<PageResponse<Investment>> {
+  async fetchInvestments(
+    itemId: string,
+    type?: InvestmentType
+  ): Promise<PageResponse<Investment>> {
     return this.createGetRequest('investments', { itemId, type })
   }
 
   /**
    * Fetch a single investment
    * @returns {Investment} an investment object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If transaction does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchInvestment(id: string): Promise<Investment> {
     return this.createGetRequest(`investments/${id}`)
@@ -174,6 +223,9 @@ class Pluggy extends BaseApi {
   /**
    * Fetch the identity resource
    * @returns {IdentityResponse} an identity object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If identity does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchIdentity(id: string): Promise<IdentityResponse> {
     return this.createGetRequest(`identity/${id}`)
@@ -182,6 +234,8 @@ class Pluggy extends BaseApi {
   /**
    * Fetch the identity resource by it's Item ID
    * @returns {IdentityResponse} an identity object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 403 if user is unauthorized
    */
   async fetchIdentityByItemId(itemId: string): Promise<IdentityResponse> {
     return this.createGetRequest(`identity?itemId=${itemId}`)
@@ -190,6 +244,9 @@ class Pluggy extends BaseApi {
   /**
    * Fetch all available categories
    * @returns {PageResponse<Category>[]} an paging response of categories
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If identity does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async fetchCategories(): Promise<PageResponse<Category>> {
     return this.createGetRequest('categories')
@@ -198,6 +255,9 @@ class Pluggy extends BaseApi {
   /**
    * Fetch a single category
    * @returns {Category} a category object
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If category does not exist
+   *                                     status 403 if user is unauthorized
    */
   async fetchCategory(id: string): Promise<Category> {
     return this.createGetRequest(`categories/${id}`)
@@ -206,6 +266,9 @@ class Pluggy extends BaseApi {
   /**
    * Creates a connect token that can be used as API KEY to connect items from the Frontend
    * @returns {string} Access token to connect items with restrict access
+   *
+   * @throws {AxiosError<ErrorResponse>} status 404 If specified Item by 'id' does not exist or is not accessible by the user,
+   *                                     status 403 if user is unauthorized
    */
   async createConnectToken(itemId?: string): Promise<{ accessToken: string }> {
     return this.createPostRequest(`connect_token`, null, { itemId })


### PR DESCRIPTION
* Fix: Properly document API errors as thrown results instead of returned values (HTTP statuses > 300)
* Provide type-guards to narrow and extract the error responses from the thrown AxiosError instances