### PR TITLE
fix(baseApi): add current pluggy-js and axios version into User-Agent.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "pluggy-js",
-  "version": "0.2.9",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.9",
+      "name": "pluggy-js",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1"
@@ -5728,6 +5729,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -14,6 +14,7 @@ function jsonParseDateReviver(_key, value: unknown): Date | unknown {
 }
 
 const PLUGGY_JS_VERSION = '0.8.0'
+const AXIOS_VERSION = '^0.21.1'
 
 export class BaseApi {
   private service: AxiosInstance
@@ -34,7 +35,7 @@ export class BaseApi {
         headers: {
           // note: we should update manually the version of Pluggy-js in the User-Agent since we are in client-side
           // so we don't have access to the package-json versions.
-          'User-Agent': `Pluggy-js/${PLUGGY_JS_VERSION}`,
+          'User-Agent': `Pluggy-js/${PLUGGY_JS_VERSION} Axios/${AXIOS_VERSION}`,
           'X-API-KEY': this.apiKey,
           'Content-Type': 'application/json',
         },

--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -32,8 +32,8 @@ export class BaseApi {
     if (!this.service) {
       const config: AxiosRequestConfig = {
         headers: {
-          // note: we should update manually the version of the user agent since we are client-side
-          // and we don't have access to the package
+          // note: we should update manually the version of Pluggy-js in the User-Agent since we are in client-side
+          // so we don't have access to the package-json versions.
           'User-Agent': `Pluggy-js/${PLUGGY_JS_VERSION}`,
           'X-API-KEY': this.apiKey,
           'Content-Type': 'application/json',

--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -13,7 +13,7 @@ function jsonParseDateReviver(_key, value: unknown): Date | unknown {
   return isIsoDateString(value) ? parseIsoDate(value) : value
 }
 
-const PLUGGY_JS_VERSION = '0.8.0'
+const PLUGGY_JS_VERSION = '0.7.2'
 const AXIOS_VERSION = '^0.21.1'
 
 export class BaseApi {

--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -13,6 +13,8 @@ function jsonParseDateReviver(_key, value: unknown): Date | unknown {
   return isIsoDateString(value) ? parseIsoDate(value) : value
 }
 
+const PLUGGY_JS_VERSION = '0.8.0'
+
 export class BaseApi {
   private service: AxiosInstance
   private apiKey: string
@@ -30,6 +32,9 @@ export class BaseApi {
     if (!this.service) {
       const config: AxiosRequestConfig = {
         headers: {
+          // note: we should update manually the version of the user agent since we are client-side
+          // and we don't have access to the package
+          'User-Agent': `Pluggy-js/${PLUGGY_JS_VERSION}`,
           'X-API-KEY': this.apiKey,
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
I didn't add the Axios version since we use "^0.21.1" and use the "^" so clients will have different compatible versions of the module depending on when they did the `npm install`.