### PR TITLE
fix(baseApi): prevent browser error by overriding 'User-Agent', set custom header instead.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pluggy-js",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pluggy-js",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1"

--- a/src/baseApi.ts
+++ b/src/baseApi.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 import { isIsoDateString, parseIsoDate } from './utils'
+import { AXIOS_VERSION, PLUGGY_JS_VERSION } from './version'
 
 type QueryParameters = {
   [key: string]: number | number[] | string | string[] | boolean
@@ -12,9 +13,6 @@ type QueryParameters = {
 function jsonParseDateReviver(_key, value: unknown): Date | unknown {
   return isIsoDateString(value) ? parseIsoDate(value) : value
 }
-
-const PLUGGY_JS_VERSION = '0.8.0'
-const AXIOS_VERSION = '^0.21.1'
 
 export class BaseApi {
   private service: AxiosInstance
@@ -33,9 +31,7 @@ export class BaseApi {
     if (!this.service) {
       const config: AxiosRequestConfig = {
         headers: {
-          // note: we should update manually the version of Pluggy-js in the User-Agent since we are in client-side
-          // so we don't have access to the package-json versions.
-          'User-Agent': `Pluggy-js/${PLUGGY_JS_VERSION} Axios/${AXIOS_VERSION}`,
+          'Pluggy-User-Agent': `PluggyJs/${PLUGGY_JS_VERSION} Axios/${AXIOS_VERSION}`,
           'X-API-KEY': this.apiKey,
           'Content-Type': 'application/json',
         },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+// Project versions
+// Needs to be updated manually since in client-side, we don't have access to the package.json file.
+export const PLUGGY_JS_VERSION = '0.8.1'
+export const AXIOS_VERSION = '^0.21.1'


### PR DESCRIPTION
set custom UA header, instead of 'User-Agent', as it's "reserved" in chromium based browsers which leads to requests not working.

source https://stackoverflow.com/a/67952174/6279385
