### PR TITLE
feat(pluggy): add "options" parameter to createConnectToken to pass clientUserId and webhookUrl.

### DIFF
--- a/src/pluggy.ts
+++ b/src/pluggy.ts
@@ -14,6 +14,7 @@ import {
   TransactionFilters,
   Parameters,
   ListResponse,
+  ConnectTokenOptions,
 } from './types'
 
 /**
@@ -274,13 +275,15 @@ class Pluggy extends BaseApi {
 
   /**
    * Creates a connect token that can be used as API KEY to connect items from the Frontend
+   * @param  {string} itemId - primary identifier of the Item
+   * @param {ConnectTokenOptions} options - options object to create a connect token
    * @returns {string} Access token to connect items with restrict access
    *
    * @throws {AxiosError<ErrorResponse>} status 404 If specified Item by 'id' does not exist or is not accessible by the user,
    *                                     status 403 if user is unauthorized
    */
-  async createConnectToken(itemId?: string): Promise<{ accessToken: string }> {
-    return this.createPostRequest(`connect_token`, null, { itemId })
+  async createConnectToken(itemId?: string, options?: ConnectTokenOptions): Promise<{ accessToken: string }> {
+    return this.createPostRequest(`connect_token`, null, { itemId, options })
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,17 @@ export type TransactionFilters = {
 }
 
 /**
+ * @typedef ConnectTokenOptions
+ * @type {object}
+ * @property {string} clientUserId - Client's identifier for the user, it can be a ID, UUID or even an email.
+ * @property {string} webhookUrl - Url to be notified of this specific item changes
+ */
+export type ConnectTokenOptions = {
+  clientUserId?: string
+  webhookUrl?: string
+}
+
+/**
  * @typedef ConnectorFilters
  * @type {object}
  * @property {string} name - Connector´s name or alike name

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 // Project versions
 // Needs to be updated manually since in client-side, we don't have access to the package.json file.
-export const PLUGGY_JS_VERSION = '0.8.3'
+export const PLUGGY_JS_VERSION = '0.9.3'
 export const AXIOS_VERSION = '^0.21.1'

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 // Project versions
 // Needs to be updated manually since in client-side, we don't have access to the package.json file.
-export const PLUGGY_JS_VERSION = '0.9.3'
+export const PLUGGY_JS_VERSION = '0.9.0'
 export const AXIOS_VERSION = '^0.21.1'


### PR DESCRIPTION
[JIRA](https://pluggy.atlassian.net/browse/INT-248)

## What?
* add "options" parameter to createConnectToken to pass clientUserId and webhookUrl.

## Why?
to add full support to POST /connect-token api endpoint from pluggy-js

✅ tested locally
